### PR TITLE
feat: improve report filenames with descriptive naming convention

### DIFF
--- a/src/scripts/multi-page-audit.ts
+++ b/src/scripts/multi-page-audit.ts
@@ -251,7 +251,7 @@ async function main() {
         'console': 'txt'
       }[reportFormat as 'html' | 'json' | 'markdown' | 'console'] || 'html';
       
-      const fileName = `multi-page-audit-${domainName}-${crawlStrategy}-${criteriaSet}-${timestamp}.${fileExtension}`;
+      const fileName = `full-site-${domainName}-${timestamp}.${fileExtension}`;
       const filePath = path.join(process.cwd(), 'reports', fileName);
       
       // Criar diretório de relatórios se não existir

--- a/src/scripts/wcag-validation.ts
+++ b/src/scripts/wcag-validation.ts
@@ -116,7 +116,6 @@ async function main() {
       
       const timestamp = new Date().toISOString().replace(/[:.]/g, '-').split('T')[0];
       const domainName = new URL(targetUrl).hostname.replace(/[^a-zA-Z0-9]/g, '-');
-      const auditTypeShort = isCompleteAudit ? 'complete' : 'simple';
       
       const fileExtension = {
         json: 'json',
@@ -124,7 +123,7 @@ async function main() {
         markdown: 'md'
       }[reportFormat];
       
-      const fileName = `accessibility-report-${domainName}-${auditTypeShort}-${timestamp}.${fileExtension}`;
+      const fileName = `single-page-${domainName}-${timestamp}.${fileExtension}`;
       const filePath = path.join(process.cwd(), 'reports', fileName);
       
       // Criar diretório de relatórios se não existir


### PR DESCRIPTION
Implement descriptive naming convention for HTML report files: full-site-<URL>-<date>.html and single-page-<URL>-<date>.html